### PR TITLE
Correct small typo in tooltip

### DIFF
--- a/src/views/main.html
+++ b/src/views/main.html
@@ -21,7 +21,7 @@
         <div role="tooltip" id="free-value-tooltip-fg">
             Supported formats are: 
             <ul>
-              <li>Hex: #FFF, #FFFA, #FFFFFFF</li>
+              <li>Hex: #FFF, #FFFA, #FFFFFFAA</li>
               <li>Names: blue (<a href="https://www.w3.org/TR/css-color-3/#svg-color" target="_blank">Full list</a>)</li>
               <li>RGB: rgb(200,200,200), rgba(200,60,60,0.3)</li>
               <li>HSL: hsl(360,100%,50%), hsla(360,60%,50%,0.4)</li>


### PR DESCRIPTION
8 values, not 7. also, uses `A` for clarity to hint that it's the alpha

xref https://github.com/ThePacielloGroup/CCAe/issues/22