### PR TITLE
Explicitly set a styled focus indication outline

### DIFF
--- a/src/views/css/global.css
+++ b/src/views/css/global.css
@@ -51,7 +51,12 @@ button:focus {
     width: 1px;
 }
 
+.js-focus-visible :focus {
+    outline: 0.25em rgba(0,0,0,0.4) solid;
+    box-shadow: 0 0 3em 0.05em rgba(255,255,255,0.8);
+}
+
 /* https://github.com/WICG/focus-visible */
 .js-focus-visible :focus:not(.focus-visible) {
     outline: none;
-  }
+}


### PR DESCRIPTION
The default seems to be some random red colour (at least on Windows) which doesn't really go/match anything of the visual style here.
Hoping that a combination of outline and an ever-so-subtle glowing white box shadow will work on different backgrounds.

Current focus indication (thin red outline)
> ![cca-focus2](https://user-images.githubusercontent.com/895831/45040337-afa3e100-b05d-11e8-85a7-9aec14eb5618.PNG)

Proposed focus indication (grey semi-transparent outline plus subtle white outline glow)
> ![cca-focus1](https://user-images.githubusercontent.com/895831/45040673-6f912e00-b05e-11e8-9451-e266d4e6f64c.PNG)