### PR TITLE
Restyle help sections

### DIFF
--- a/src/views/css/main.css
+++ b/src/views/css/main.css
@@ -53,6 +53,7 @@ section {
 }
 
 /* Color sections */
+
 section#foreground-color, 
 section#background-color {
     display: flex;
@@ -70,7 +71,7 @@ section#background-color .buttons {
 }
 
 /* Free text input */
-/* Tooltips*/
+
 section#foreground-color .container,
 section#background-color .container {
     position: relative;
@@ -185,6 +186,7 @@ section#background-color button[aria-pressed=true] {
 }
 
 /* RGB input sections */
+
 section#foreground-rgb .sync,
 section#background-rgb .sync {
     text-align: right;
@@ -218,6 +220,23 @@ section#background-rgb input[type=number]::-webkit-outer-spin-button {
     margin: 0;
 }
 
+/* Help section */
+
+section#foreground-help,
+section#background-help {
+    background: #f5f5f5;
+    line-height: 1.5;
+}
+
+section#foreground-help code,
+section#background-help code {
+    font-size: 1.1em;
+    background: #ffffb3;
+    padding: 0.1em;
+    border: 1px #aaa solid;
+    border-radius: 3px;
+}
+
 /* Sample preview section */
 
 section#sample-preview .preview-box {
@@ -245,6 +264,7 @@ section#sample-preview .icon svg {
 }
 
 /* Results section */
+
 section#results {
     background-color: #ffffff;
 }

--- a/src/views/main.html
+++ b/src/views/main.html
@@ -31,10 +31,10 @@
       <section id="foreground-help" hidden>
         Supported formats are: 
         <ul>
-          <li>Hex: #FFF, #FFFFFF, #FFFA, #FFFFFFAA</li>
-          <li>Names: blue, grey, orange, ...</li>
-          <li>RGB: rgb(200,200,200), rgba(200,60,60,0.3)</li>
-          <li>HSL: hsl(360,100%,50%), hsla(360,60%,50%,0.4)</li>
+          <li>Hex: <code>#FFF</code>, <code>#FFFFFF</code>, <code>#FFFA</code>, <code>#FFFFFFAA</code></li>
+          <li>Names: <code>blue</code>, <code>grey</code>, <code>orange</code>, ...</li>
+          <li>RGB: <code>rgb(200,200,200)</code>, <code>rgba(200,60,60,0.3)</code></li>
+          <li>HSL: <code>hsl(360,100%,50%)</code>, <code>hsla(360,60%,50%,0.4)</code></li>
         </ul>
       </section>
       <section id="foreground-rgb" hidden>
@@ -84,10 +84,10 @@
       <section id="background-help" hidden>
         Supported formats are: 
         <ul>
-          <li>Hex: #FFF, #FFFFFF</li>
-          <li>Names: blue, grey, orange, ...</li>
-          <li>RGB: rgb(200,200,200)</li>
-          <li>HSL: hsl(360,100%,50%)</li>
+          <li>Hex: <code>#FFF</code>, <code>#FFFFFF</code></li>
+          <li>Names: <code>blue</code>, <code>grey</code>, <code>orange</code>, ...</li>
+          <li>RGB: <code>rgb(200,200,200)</code></li>
+          <li>HSL: <code>hsl(360,100%,50%)</code></li>
         </ul>
       </section>
       <section id="background-rgb" hidden>


### PR DESCRIPTION
- wrap formats in `<code>`
- apply some (heavy handed?) styling

> ![cca-help-restyle](https://user-images.githubusercontent.com/895831/45083213-19ba9580-b0f3-11e8-9805-b25856406371.PNG)
