### PR TITLE
Fixes to alpha slider/input

### DIFF
--- a/src/views/js/main.js
+++ b/src/views/js/main.js
@@ -120,7 +120,11 @@ function applyColor(section) {
     document.querySelector('#' + section + '-rgb .blue input[type=number]').value = color.blue()
     if (section === 'foreground') {
         document.querySelector('#' + section + '-rgb .alpha input[type=range]').value = color.alpha()
-        document.querySelector('#' + section + '-rgb .alpha input[type=number]').value = color.alpha()    
+        if (document.activeElement != document.querySelector('#' + section + '-rgb .alpha input[type=number]')) {
+            /* only force update of the alpha number input if it's not current;y focused
+               as otherwise, when user enters "0.", it's corrected to "0" and prevents correct text entry */
+            document.querySelector('#' + section + '-rgb .alpha input[type=number]').value = color.alpha()
+        }  
         document.querySelector('#sample-preview .text').style.color = colorRGB
         document.querySelector('#sample-preview .icon svg').style.fill = colorRGB    
     } else {

--- a/src/views/main.html
+++ b/src/views/main.html
@@ -63,7 +63,7 @@
           <div class="slider alpha">
             <label>Alpha</label>
             <input aria-label="Foreground alpha" type="range" min="0" max="1" value="1" step="0.01" />
-            <input aria-label="Foreground alpha" type="number" min="0" max="1" />
+            <input aria-label="Foreground alpha" type="number" min="0" max="1" step="0.0001" />
           </div>
         </div>
       </section>

--- a/src/views/main.html
+++ b/src/views/main.html
@@ -62,8 +62,8 @@
           </div>
           <div class="slider alpha">
             <label>Alpha</label>
-            <input aria-label="Foreground alpha" type="range" min="0" max="1" value="1" step="0.1" />
-            <input aria-label="Foreground alpha" type="number" maxlength="3" />
+            <input aria-label="Foreground alpha" type="range" min="0" max="1" value="1" step="0.01" />
+            <input aria-label="Foreground alpha" type="number" min="0" max="1" />
           </div>
         </div>
       </section>


### PR DESCRIPTION
- increased granularity of alpha slider (in `0.01` steps)
- fixes the number input using correct `min` and `max` (and an added `step` to keep the freeform entry sensibly long - though note blink/electron don't seem to enforce this yet)
- works around issue of user not being able to manually type alpha / "0." being corrected immediately to "0"

Closes https://github.com/ThePacielloGroup/CCAe/issues/60