### PR TITLE
Add cut/copy/paste to Edit menu on macOS

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -100,6 +100,26 @@ app.on('ready', () => {
         }
     ];
 
+    if (process.platform === 'darwin') {
+        menuTemplate[1].submenu.push(
+            {
+                type: 'separator'
+            }, {
+                label: 'Cut',
+                accelerator: 'CmdOrCtrl+X',
+                selector: 'cut:'
+            }, {
+                label: 'Copy',
+                accelerator: 'CmdOrCtrl+C',
+                selector: 'copy:'
+            }, {
+                label: 'Paste',
+                accelerator: 'CmdOrCtrl+V',
+                selector: 'paste:'
+            }
+        )
+    }
+
     if (isDev) {
         menuTemplate.push(
             {


### PR DESCRIPTION
By default, macOS electron does not implement standard Cmd+X/Cmd+C/Cmd+V - adding relevant menu options in the Edit menu fixes this (without the need for any custom clipboard API code).

These options are only added on macOS builds, as on Windows/Linux electron Ctrl+X/Ctrl+C/Ctrl+V work out of the box.

Closes https://github.com/ThePacielloGroup/CCAe/issues/88