### PR TITLE
Move picker by arrow keys

### DIFF
--- a/src/controllers/picker.js
+++ b/src/controllers/picker.js
@@ -3,9 +3,6 @@ const {ipcMain} = require('electron')
 const robot = require('robotjs')
 
 let mouseEvent
-if (process.platform === 'darwin') mouseEvent = require('osx-mouse')()
-// if (process.platform === 'linux') mouseEvent = require('linux-mouse')()
-if (process.platform === 'win32') mouseEvent = require('win-mouse')()
 
 module.exports = (browsers, mainController) => {
     const {picker, main} = browsers
@@ -68,6 +65,10 @@ module.exports = (browsers, mainController) => {
     })
 
     ipcMain.on('pickerRequested', (event, ratio) => {    
+        if (process.platform === 'darwin') mouseEvent = require('osx-mouse')()
+        // if (process.platform === 'linux') mouseEvent = require('linux-mouse')()
+        if (process.platform === 'win32') mouseEvent = require('win-mouse')()
+      
         picker.getWindow().on('close', () => mouseEvent.destroy())
     
         mouseEvent.on('move', (x, y) => {

--- a/src/controllers/picker.js
+++ b/src/controllers/picker.js
@@ -52,6 +52,11 @@ module.exports = (browsers, mainController) => {
       }
     }
 
+    let selectColor = () => {
+      const currentMousePos = robot.getMousePos();
+      closePicker('#' + robot.getPixelColor(currentMousePos.x, currentMousePos.y))
+    }
+
     ipcMain.on('showForegroundPicker', event => {
       foregroundPicker = true
       picker.init()
@@ -109,4 +114,5 @@ module.exports = (browsers, mainController) => {
     ipcMain.on('movePickerRight', (evt) => movePicker('right'))
     ipcMain.on('movePickerDown', (evt) => movePicker('down'))
     ipcMain.on('movePickerLeft', (evt) => movePicker('left'))
+    ipcMain.on('selectPickerColor', (evt) => selectColor())
 }

--- a/src/controllers/picker.js
+++ b/src/controllers/picker.js
@@ -9,15 +9,15 @@ if (process.platform === 'win32') mouseEvent = require('win-mouse')()
 
 module.exports = (browsers, mainController) => {
     const {picker, main} = browsers
-    let foregroundPicker // Keep which picker is openned
+    let foregroundPicker // Keep which picker is opened
 
     let closePicker = hexColor => {
       if (picker.getWindow()) {
         picker.getWindow().close()
         if (foregroundPicker === true) {
-          mainController.sendEventToAll('foregroundPickerToggelled', false)   
+          mainController.sendEventToAll('foregroundPickerToggled', false)   
         } else {
-          mainController.sendEventToAll('backgroundPickerToggelled', false)   
+          mainController.sendEventToAll('backgroundPickerToggled', false)   
         }
         if (typeof hexColor === 'string') { // If ESC wasn't used
           if (foregroundPicker === true) {
@@ -58,12 +58,13 @@ module.exports = (browsers, mainController) => {
     ipcMain.on('showForegroundPicker', event => {
       foregroundPicker = true
       picker.init()
-      mainController.sendEventToAll('foregroundPickerToggelled', true)   
+      mainController.sendEventToAll('foregroundPickerToggled', true)   
     })
+
     ipcMain.on('showBackgroundPicker', event => { 
       foregroundPicker = false
       picker.init()
-      mainController.sendEventToAll('backgroundPickerToggelled', true)   
+      mainController.sendEventToAll('backgroundPickerToggled', true)   
     })
 
     ipcMain.on('pickerRequested', (event, ratio) => {    

--- a/src/views/js/main.js
+++ b/src/views/js/main.js
@@ -23,11 +23,11 @@ ipcRenderer.on('backgroundColorChanged', event => {
     applyContrastRatio()
 })
 
-ipcRenderer.on('foregroundPickerToggelled', (event, state) => {
+ipcRenderer.on('foregroundPickerToggled', (event, state) => {
     document.querySelector('#foreground-color .picker').setAttribute('aria-pressed', state)
 })
 
-ipcRenderer.on('backgroundPickerToggelled', (event, state) => {
+ipcRenderer.on('backgroundPickerToggled', (event, state) => {
     document.querySelector('#background-color .picker').setAttribute('aria-pressed', state)
 })
 

--- a/src/views/js/picker.js
+++ b/src/views/js/picker.js
@@ -4,7 +4,17 @@ document.querySelector('#picker').style.border = `10px solid rgba(200, 200, 200,
 
 document.addEventListener('DOMContentLoaded', () => ipcRenderer.send('pickerRequested', window.devicePixelRatio), false)
 document.addEventListener('keydown', event => {
-  if (event.key === 'Escape') ipcRenderer.send('closePicker')
+  if (event.key === 'Escape') {
+    ipcRenderer.send('closePicker')
+  } else if (event.key === 'ArrowUp') {
+    ipcRenderer.send('movePickerUp');
+  } else if (event.key === 'ArrowRight') {
+    ipcRenderer.send('movePickerRight');
+  } else if (event.key === 'ArrowDown') {
+    ipcRenderer.send('movePickerDown');
+  } else if (event.key === 'ArrowLeft') {
+    ipcRenderer.send('movePickerLeft');
+  }
 }, false)
 
 ipcRenderer.on('updatePicker', (event, color) => {

--- a/src/views/js/picker.js
+++ b/src/views/js/picker.js
@@ -16,6 +16,13 @@ document.addEventListener('keydown', event => {
     ipcRenderer.send('movePickerLeft');
   }
 }, false)
+document.addEventListener('keyup', event => {
+  if (event.key === 'Enter') {
+    ipcRenderer.send('selectPickerColor');
+  } else if (event.code === 'Space') {
+    ipcRenderer.send('selectPickerColor');
+  }
+}, false)
 
 ipcRenderer.on('updatePicker', (event, color) => {
   document.querySelector('#picker').style.border = `10px solid ${color}`


### PR DESCRIPTION
Fixes #84 	

Known issues with this fix include:

* In a multi-monitor setup, the dimensions of the primary monitor are used as the outer limits. So it is possible to get into a situation where,
	* when the primary monitor is larger, you can move the picker off the screen with the keyboard
	* when the primary monitor is smaller, you cannot move the picker with the keyboard if you are outside of the dimensions of the primary monitor
