### PR TITLE
Sanitize text output before writing to clipboard

### DIFF
--- a/src/CCAcontroller.js
+++ b/src/CCAcontroller.js
@@ -239,6 +239,9 @@ The contrast ratio is: ${normal.contrastRatioString}
 1.4.11 Non-text Contrast (AA)
     ${level_1_4_11}`
 
+        // sanitize output (if there's HTML, e.g. in "just below" case)
+        text = text.replace(/<[^>]*>?/g, '')
+
         clipboard.writeText(text)
     }
 


### PR DESCRIPTION
fixes issue with HTML making its way into the clipboard text when contrast is "just below..."

Closes https://github.com/ThePacielloGroup/CCAe/issues/101