### PR TITLE
prevent accidental publish to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "version": "1.1.2",
     "description": "Colour Contrast Analyser (CCA)",
     "main": "src/main.js",
+    "private": true,
     "scripts": {
         "test": "echo \"Error: no test specified\" && exit 1",
         "start": "cross-env NODE_ENV=dev electron .",


### PR DESCRIPTION
the package is named `CCA` but this doesn't appear to be in npm, I'm assuming intentionally. Adding `"private": true` will prevent it from an accidental publish.