### PR TITLE
fix: missing quit menu label.

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -65,7 +65,7 @@ app.on('ready', () => {
                 }, {
                     type: 'separator'
                 }, {
-                    // label: i18n.menuT('quit AAAA'),
+                    label: i18n.menuT('Quit CCA'),
                     role: 'quit',
                     accelerator: 'CmdOrCtrl+Q'
                 }


### PR DESCRIPTION
I'm sorry! Something accidentally commented out of the "Exit App" menu label remained.