### PR TITLE
Fix "just below" display

### DIFF
--- a/src/CCAcontroller.js
+++ b/src/CCAcontroller.js
@@ -328,6 +328,7 @@ class CCAController {
             levelAAA: this.sharedObject['general.levelAAA'],
             raw: cr,
             rounded: crr,
+            rounding: rounding,
         }
         const def = ['achromatopsia', 'achromatomaly', 'protanopia', 'protanomaly', 'deuteranopia', 'deuteranomaly', 'tritanopia', 'tritanomaly']
         def.forEach(key => {

--- a/src/views/js/main.js
+++ b/src/views/js/main.js
@@ -365,9 +365,11 @@ function applyContrastRatio(contrastRatio) {
 
     let cr = contrastRatio.raw
     let crr = contrastRatio.rounded.toLocaleString(i18n.lang)
+    let r = contrastRatio.rounding
     // toLocalString removes trailing zero and use the correct decimal separator, based on the app select lang.
     contrastRatioString = `${crr}:1`
-    if ((cr >= 6.95 && cr < 7) || (cr >= 4.45 && cr < 4.5) || (cr >= 2.95 && cr < 3)) {
+    if (((r == 1) && ((cr >= 6.95 && cr < 7) || (cr >= 4.45 && cr < 4.5) || (cr >= 2.95 && cr < 3))) || 
+        ((r == 2) && ((cr >= 6.995 && cr < 7) || (cr >= 4.495 && cr < 4.5) || (cr >= 2.995 && cr < 3)))) {
         let crr3 = cr.toLocaleString(i18n.lang)
         contrastRatioString = `<span class="smaller">${i18n["just below"]} </span>${crr}:1<span class="smaller"> (${crr3}:1)</span>`
     }


### PR DESCRIPTION
Currently, the "just below" text is displayed at inappropriate points when "decimals" is set to 2.

![screenshot of CCAe showing the ratio 'just below 2.95:1 (2.952:1)'](https://github.com/ThePacielloGroup/CCAe/assets/895831/01d707e6-c46f-4837-9c77-2274c3b70d1e)

It should only show if there's a rounding happening one decimal point below the currently set decimal display, and only if it's just below 3, 4.5, or 7.

This PR adds more nuance to the big `if` used to decide when to show the "just below" bit.

![CCAe with the same colours, but now showing just '2.96:1'](https://github.com/ThePacielloGroup/CCAe/assets/895831/e0cc6069-e392-4a2c-94fe-35b2edb38b72)
